### PR TITLE
Update foundry.toml config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 
 # Compiler optimization options to use (use same as project)
 optimizer = true                                              # enable or disable the solc optimizer
@@ -7,14 +7,15 @@ optimizer_runs = 10000                                        # the number of op
 # Turn on if you want to make use of shell commands via Solidity contracts
 ffi = true                                                    # whether to enable ffi or not
 
-# Fuzz run options - adjust as needed for your fuzzing campaign
-fuzz_runs = 999999999                                         # the number of fuzz runs for tests
-fuzz_max_local_rejects = 999999999                            # max number of individual inputs that may be rejected before the test aborts
-fuzz_max_global_rejects = 999999999                           # max number of combined inputs that may be rejected before the test aborts
-
 # Other
 verbosity = 3                                                 # the verbosity of tests (3 displays traces for failed tests)
 evm_version = 'london'                                        # the evm version (by hardfork name)
 auto_detect_solc = true                                       # enable auto-detection of the appropriate solc version to use
 cache = true                                                  # whether to cache builds or not
 force = false                                                 # whether to ignore the cache (clean build)
+
+# Fuzz run options - adjust as needed for your fuzzing campaign
+[fuzz]
+runs = 999999999                                         # the number of fuzz runs for tests
+max_local_rejects = 999999999                            # max number of individual inputs that may be rejected before the test aborts
+max_test_rejects = 999999999                           # max number of combined inputs that may be rejected before the test aborts


### PR DESCRIPTION
Add the correct config section headers, remove `fuzz_` prefixes and rename `max_global_rejects`. 
Foundry does not appear to recognize the fuzzing config options if they are not under the `[fuzz]` header. See the [default config](https://book.getfoundry.sh/static/config.default.toml) and [config reference for fuzzing](https://book.getfoundry.sh/reference/config/testing#fuzz).
Also `max_global_rejects` was depreciated and replaced with `max_test_rejects`. I am not sure about `max_local_rejects`. I don't see it anywhere in the docs but I also didn't get any warning about it being depreciated, so I don't know if it should be replaced with something else or just removed.